### PR TITLE
added timeout & disabled concurrent jobs

### DIFF
--- a/mwdevel/mwci/ggus-report.groovy
+++ b/mwdevel/mwci/ggus-report.groovy
@@ -13,8 +13,9 @@ pipeline {
   }
   
   options {
-    timeout(time: 1, unit: 'HOURS')
+    timeout(time: 10, unit: 'MINUTES')
     buildDiscarder(logRotator(numToKeepStr: '5'))
+    disableConcurrentBuilds()
   }
 
   triggers { cron('H/20 * * * *') }


### PR DESCRIPTION
Tested in 'build-ggus-report-75240' (timeout set to 2 seconds)