### PR TITLE
Mwci 274

### DIFF
--- a/mwdevel/argus/docker_builds-argus-deployment-images.groovy
+++ b/mwdevel/argus/docker_builds-argus-deployment-images.groovy
@@ -33,8 +33,6 @@ pipeline {
     stage('build images') {
       steps {
         parallel (
-          "centos6-allinone"   : { build_image('centos6', 'all-in-one') },
-          "centos6-distributed": { build_image('centos6', 'distributed') },
           "centos7-allinone"   : { build_image('centos7', 'all-in-one') },
           "centos7-distributed": { build_image('centos7', 'distributed') },
         )

--- a/mwdevel/argus/docker_builds-argus-deployment-images.groovy
+++ b/mwdevel/argus/docker_builds-argus-deployment-images.groovy
@@ -5,9 +5,11 @@ def build_image(platform, deployment){
     deleteDir()
     unstash "source"
 
-    dir("${deployment}") {
-      sh "PLATFORM=${platform} sh build-images.sh"
-      sh "PLATFORM=${platform} sh push-images.sh"
+    withDockerRegistry([ credentialsId: "dockerhub-enrico", url: "" ]) {
+      dir("${deployment}") {
+        sh "PLATFORM=${platform} sh build-images.sh"
+        sh "PLATFORM=${platform} sh push-images.sh"
+      }
     }
   }
 }


### PR DESCRIPTION
* removed centos6 platform from argus-deployment-images build
* added valid credentials for docker registry
Tested on Jenkins, now the job ends with success: 
https://ci.cloud.cnaf.infn.it/view/argus/job/docker_build-argus-deployment-images/1556/